### PR TITLE
altering the order of the variables populates the var-namespace field…

### DIFF
--- a/frontend/src/app/pages/server-info/server-info.component.html
+++ b/frontend/src/app/pages/server-info/server-info.component.html
@@ -51,8 +51,8 @@
         <mat-tab *ngIf="grafanaFound" label="METRICS">
           <app-metrics
             *ngIf="serverInfoLoaded"
-            [status]="inferenceService?.status"
             [namespace]="namespace"
+            [status]="inferenceService?.status"
           ></app-metrics>
         </mat-tab>
         <mat-tab label="LOGS">


### PR DESCRIPTION
… instead of leaving it as undefined in the metrics tab

Signed-off-by: Author Name paloma.rebuelta@6point6.co.uk
Signed-off-by: Paloma Rebuelta <paloma.rebuelta@6point6.co.uk>

format changes